### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/src/utils/docIngester.ts
+++ b/src/utils/docIngester.ts
@@ -173,6 +173,14 @@ export function entriesToTranslationData(
   entries: ParsedDocEntry[],
   locale: string,
 ): TranslationData {
+  if (
+    locale === '__proto__' ||
+    locale === 'constructor' ||
+    locale === 'prototype'
+  ) {
+    return {};
+  }
+
   const data: TranslationData = {};
   data[locale] = {};
 


### PR DESCRIPTION
Potential fix for [https://github.com/el-j/google-sheet-translations/security/code-scanning/6](https://github.com/el-j/google-sheet-translations/security/code-scanning/6)

In general, to fix this type of problem you must ensure that untrusted strings are not used as plain object property names on objects with `Object.prototype` in their prototype chain. You can do this by either (1) switching to a safe structure such as `Map` or `Object.create(null)`, or (2) validating/rejecting dangerous keys like `__proto__`, `constructor`, and `prototype` before using them as property names.

For this code, the smallest, least disruptive fix is to explicitly guard `locale` against prototype-polluting values, exactly as is already done for `sheetName` and `entryKey`. This preserves the existing `TranslationData` shape (a nested object structure) so downstream consumers are unaffected. Concretely:
- At the start of `entriesToTranslationData`, add a check that returns an empty `TranslationData` if `locale` is one of the dangerous names.
- Optionally, we could also consider using `Object.create(null)` for the top-level `data` object to be extra defensive, but that is not strictly required once `locale` is validated; given we must avoid changing behavior, simply validating `locale` is the minimal and clearest fix.

Implementation details in `src/utils/docIngester.ts`:
- In `entriesToTranslationData`, right after the function signature and before `const data: TranslationData = {};`, add a guard:

  ```ts
  if (
    locale === '__proto__' ||
    locale === 'constructor' ||
    locale === 'prototype'
  ) {
    return {};
  }
  ```

- No new imports, methods, or type changes are required; this is purely a defensive runtime check on function input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
