### PR TITLE
docs: highlight v3 provider platform, headless cryptpad sync, and update changelog

### DIFF
--- a/website/changelog.md
+++ b/website/changelog.md
@@ -12,6 +12,29 @@ Every commit to `main` that contains a releasable change type automatically:
 
 ---
 
+## 🚀 What's new in v3.0 (Universal Provider Platform)
+
+Version 3.0 evolves `@el-j/google-sheet-translations` into an extensible, provider-first localization platform supporting both **Google Sheets** and privacy-first **CryptPad**:
+
+### Universal Provider Architecture
+- Decoupled `input`, `output`, `sync`, and `assetSync` providers with explicit capability checks.
+- Zero vendor lock-in: easily implement custom providers for Airtable, Notion, CSV, or custom backends.
+
+### Native End-to-End Encrypted (E2EE) CryptPad Integration
+- **Full Bidirectional Sync**: Pull and push translations directly to password-protected CryptPad OnlyOffice spreadsheets via pure Netflux WebSockets and TweetNaCl decryption.
+- **Zero Browser Required**: Headless RT-channel auto-initialization allows creating and updating CryptPad spreadsheets without ever opening a browser.
+- **Workbook Multi-Sheet Support**: Read and write individual tabs (`common`, `auth`, `pricing`).
+- **CryptPad Drive Folder Discovery & Asset Sync**: Scan encrypted Drive folders and mirror localized image/media assets locally.
+- **Dedicated CLI**: `gst-cryptpad` binary for `pull`, `push`, `sync`, `inspect`, and `drive-scan`.
+
+### In-Place Reactive Website Translation
+- Interactive multi-language documentation powered by live Google Spreadsheet translation datasets across 8 languages.
+
+### Frictionless v2 to v3 Migration
+- `gst-migrate-v3` CLI automatically inspects v2 setups, runs parity checks, generates `provider.config.json`, and rewrites GitHub Action workflow files.
+
+---
+
 ## 🚀 What's new in v2.2.0
 
 v2.2.0 is the **Google Drive release** — the biggest feature drop since the

--- a/website/guide/cryptpad-full-sync.md
+++ b/website/guide/cryptpad-full-sync.md
@@ -64,6 +64,10 @@ CryptPad spreadsheets use the exact same tabular convention as Google Sheets:
 > [!TIP]
 > Both `"var"` and `"key"` are supported interchangeably as the key header. When reading or writing, the provider recognizes either format without requiring configuration changes.
 
+> [!TIP]
+> **Headless RT-Channel Auto-Initialization (Zero Browser Required)**:
+> Newly created CryptPad spreadsheets that have never been opened in OnlyOffice are automatically detected and initialized headlessly via pure Netflux protocol handshake on first write or push. No manual browser interaction or browser automation is ever required!
+
 ---
 
 ## 1. Quickstart: CLI Tooling

--- a/website/index.md
+++ b/website/index.md
@@ -18,8 +18,8 @@ hero:
       text: Migrate from v2
       link: /guide/provider-migration-v3
     - theme: alt
-      text: CryptPad & Providers
-      link: /guide/non-google-providers
+      text: CryptPad Full Sync
+      link: /guide/cryptpad-full-sync
     - theme: alt
       text: GitHub Action
       link: /guide/github-actions
@@ -38,9 +38,9 @@ features:
     link: /guide/provider-migration-v3
     linkText: Learn more
 
-  - title: Privacy-First with CryptPad (v3)
-    details: Pull translation tables from CryptPad CSV exports with zero authentication, sync with 3-way conflict policies, and download remote media assets.
-    link: /guide/non-google-providers
+  - title: Privacy-First CryptPad Sheets & Drive (v3)
+    details: Full bidirectional E2EE push/pull with password protection, pure Netflux WebSockets, headless auto-initialization, multi-sheet tabs, and encrypted Drive discovery.
+    link: /guide/cryptpad-full-sync
     linkText: Learn more
 
   - title: Google Sheets Full Workflow


### PR DESCRIPTION
### Summary
- Updates homepage feature cards to highlight CryptPad full bidirectional E2EE sync and link to `/guide/cryptpad-full-sync`.
- Adds prominent tip regarding headless RT-channel auto-initialization (zero browser requirement).
- Adds `🚀 What's new in v3.0` section to `website/changelog.md`.
- Verifies clean VitePress build.