### PR TITLE
fix(cryptpad): close three provider-parity gaps with Google Sheets

### DIFF
--- a/src/providers/cryptpad/client.ts
+++ b/src/providers/cryptpad/client.ts
@@ -329,12 +329,29 @@ export class CryptPadClient {
       data.sheets[sheetName] ??
       (data.sheetNames.length === 1 ? data.sheets[data.sheetNames[0]] : undefined);
     const existingRows = targetSheet?.rows ?? [];
-    const targetSheetId =
-      data.sheetIds?.[sheetName] ??
-      (data.sheetNames.length === 1 && data.sheetNames[0]
-        ? data.sheetIds?.[data.sheetNames[0]]
-        : undefined) ??
-      '6';
+
+    let targetSheetId = data.sheetIds?.[sheetName];
+    if (!targetSheetId && data.sheetNames.length === 1 && data.sheetNames[0]) {
+      targetSheetId = data.sheetIds?.[data.sheetNames[0]];
+    }
+    if (!targetSheetId) {
+      if (data.sheetNames.length > 1) {
+        // The pad already has multiple real tabs and none match `sheetName`.
+        // gst-cryptpad cannot create a new sheet tab yet (no encoder for
+        // OnlyOffice's Sheet_Add op — see providers/cryptpad/sheetParser.ts),
+        // so guessing a sheetId here would silently write changes the real
+        // OnlyOffice editor discards as referencing a nonexistent sheet.
+        throw new Error(
+          `CryptPad sheet "${sheetName}" was not found among this pad's existing tabs ` +
+            `(${data.sheetNames.join(', ')}). gst-cryptpad cannot create new sheet tabs yet: ` +
+            `open the pad in a browser, add a "${sheetName}" tab, then re-run push.`,
+        );
+      }
+      // Brand-new / never-opened pad (zero existing tabs): '6' is the
+      // empirically observed default first-sheet ID for a fresh OnlyOffice
+      // CryptPad document (see the reference binary in sheetParser.test.ts).
+      targetSheetId = '6';
+    }
 
     // Determine primary key column header ('var' or 'key')
     let keyColName = 'var';

--- a/src/providers/cryptpad/client.ts
+++ b/src/providers/cryptpad/client.ts
@@ -19,6 +19,8 @@ import {
   convertCellsToMultiSheetRows,
   groupCellsBySheet,
   buildOnlyOfficeChangePayload,
+  buildOnlyOfficeSheetAddPayload,
+  generateOnlyOfficeSheetId,
   colIndexToLetter,
   type CryptPadSheetGrid,
   type OnlyOfficeCellUpdate,
@@ -179,6 +181,56 @@ export class CryptPadClient {
   }
 
   /**
+   * Creates a new sheet tab on this pad by broadcasting a real OnlyOffice
+   * `Workbook_SheetAdd` history record to the RT channel — the same operation a
+   * real OnlyOffice browser client sends when a user clicks "Add sheet". The
+   * binary layout was derived and byte-verified against two independent live
+   * captures from an actual browser session (see issue #161); it is not a guess.
+   *
+   * If the pad has never been opened by a real OnlyOffice client (no RT channel
+   * yet), the RT channel is initialized headlessly first, matching {@link sendCellUpdates}.
+   *
+   * @param name - Display name for the new sheet tab.
+   * @param insertBeforeIndex - 0-based tab position to insert at. Defaults to appending
+   *   after all currently known tabs.
+   * @param signal - Optional AbortSignal.
+   * @returns The newly generated internal sheetId — use this for subsequent cell writes
+   *   into the new sheet.
+   */
+  async createSheet(
+    name: string,
+    insertBeforeIndex?: number,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const data = await this.fetchSheetData(signal);
+
+    let rtChannel = data.metadata.rtChannelId;
+    if (!rtChannel) {
+      this.onProgress?.(
+        'No OnlyOffice RT channel found. Initializing headlessly (no browser required)...',
+      );
+      rtChannel = await this.initializeRtChannel(signal);
+      this.onProgress?.(`RT channel initialized: ${rtChannel}`);
+      await new Promise((r) => setTimeout(r, 800));
+    }
+
+    const sheetId = generateOnlyOfficeSheetId();
+    const insertAt = insertBeforeIndex ?? data.sheetNames.length;
+
+    const wsUrl = await this.getWebsocketUrl(signal);
+    const { cryptKey, signKey } = this.getKeys();
+    const payload = buildOnlyOfficeSheetAddPayload(name, sheetId, insertAt);
+
+    await broadcastChannelMessage(wsUrl, rtChannel, cryptKey, payload, {
+      timeoutMs: this.timeoutMs,
+      signal,
+      signKey,
+    });
+
+    return sheetId;
+  }
+
+  /**
    * Fetches the complete sheet data, including raw cell coordinate mappings,
    * multi-sheet tabs, and structured rows formatted for translation ingestion.
    *
@@ -324,33 +376,19 @@ export class CryptPadClient {
     if (rows.length === 0) return 0;
 
     const data = await this.fetchSheetData(options.signal);
-    // Find target sheet tab, or fallback to first sheet if only 1 tab exists
-    const targetSheet =
-      data.sheets[sheetName] ??
-      (data.sheetNames.length === 1 ? data.sheets[data.sheetNames[0]] : undefined);
-    const existingRows = targetSheet?.rows ?? [];
 
+    let existingRows = data.sheets[sheetName]?.rows ?? [];
     let targetSheetId = data.sheetIds?.[sheetName];
-    if (!targetSheetId && data.sheetNames.length === 1 && data.sheetNames[0]) {
-      targetSheetId = data.sheetIds?.[data.sheetNames[0]];
-    }
+
     if (!targetSheetId) {
-      if (data.sheetNames.length > 1) {
-        // The pad already has multiple real tabs and none match `sheetName`.
-        // gst-cryptpad cannot create a new sheet tab yet (no encoder for
-        // OnlyOffice's Sheet_Add op — see providers/cryptpad/sheetParser.ts),
-        // so guessing a sheetId here would silently write changes the real
-        // OnlyOffice editor discards as referencing a nonexistent sheet.
-        throw new Error(
-          `CryptPad sheet "${sheetName}" was not found among this pad's existing tabs ` +
-            `(${data.sheetNames.join(', ')}). gst-cryptpad cannot create new sheet tabs yet: ` +
-            `open the pad in a browser, add a "${sheetName}" tab, then re-run push.`,
-        );
-      }
-      // Brand-new / never-opened pad (zero existing tabs): '6' is the
-      // empirically observed default first-sheet ID for a fresh OnlyOffice
-      // CryptPad document (see the reference binary in sheetParser.test.ts).
-      targetSheetId = '6';
+      // No tab named `sheetName` exists yet — create one, mirroring Google Sheets'
+      // addSheet-on-missing-sheet behavior (src/utils/spreadsheetUpdater.ts). This
+      // deliberately does NOT fall back to reusing some other existing tab just
+      // because it happens to be the only one: an exact name match or a fresh
+      // tab, same as Google, keeps push behavior identical across providers.
+      this.onProgress?.(`Sheet "${sheetName}" not found — creating it.`);
+      targetSheetId = await this.createSheet(sheetName, data.sheetNames.length, options.signal);
+      existingRows = [];
     }
 
     // Determine primary key column header ('var' or 'key')

--- a/src/providers/cryptpad/sheetOutputProvider.ts
+++ b/src/providers/cryptpad/sheetOutputProvider.ts
@@ -6,6 +6,7 @@ import type {
 import { createCapabilitySet, type ProviderCapabilitySet } from '../capabilities';
 import { CryptPadClient } from './client';
 import type { SheetRow, TranslationData } from '../../types';
+import { I18N_SHEET_NAME } from '../../constants';
 
 export interface CryptPadSheetOutputProviderOptions {
   /** Full CryptPad URL (e.g. https://cryptpad.fr/sheet/#/2/sheet/edit/seed/p/). */
@@ -51,6 +52,11 @@ export function convertTranslationsToSheetRows(
     const colHeader = reverseMapping[locale] ?? locale;
 
     for (const [sheetName, keys] of Object.entries(sheets)) {
+      // The i18n sheet is a reserved metadata sheet (locale display names).
+      // Translation key pushes must never touch it, matching the Google Sheets
+      // output/sync path (see src/utils/spreadsheetUpdater.ts).
+      if (sheetName === I18N_SHEET_NAME) continue;
+
       if (!sheetRowsMap[sheetName]) {
         sheetRowsMap[sheetName] = new Map();
       }

--- a/src/providers/cryptpad/sheetParser.ts
+++ b/src/providers/cryptpad/sheetParser.ts
@@ -429,9 +429,17 @@ export function convertCellsToSheetRows(cells: CryptPadSheetGrid): SheetRow[] {
   const headerRowIdx = sortedRowIndices[0];
   const headerCols = rowMap.get(headerRowIdx)!;
 
-  // Header mappings: colLetter -> headerName
+  // Header mappings: colLetter -> headerName, ordered by real spreadsheet column
+  // position (A, B, C, ...) rather than by the order header cells happened to
+  // appear while replaying the pad's edit history — the two can differ (e.g. a
+  // locale column added in a later push), and `transformRowsToSheetData`
+  // (src/core/rowTransformer.ts) picks the key column via `Object.keys(rows[0])[0]`,
+  // so getting this order wrong silently picks the wrong key column.
+  const orderedCols = Array.from(headerCols.entries()).sort(
+    ([colA], [colB]) => letterToColIndex(colA) - letterToColIndex(colB),
+  );
   const colToHeaderName = new Map<string, string>();
-  for (const [col, colName] of headerCols.entries()) {
+  for (const [col, colName] of orderedCols) {
     const trimmed = colName.trim();
     if (trimmed.length > 0) {
       colToHeaderName.set(col, trimmed);
@@ -448,11 +456,6 @@ export function convertCellsToSheetRows(cells: CryptPadSheetGrid): SheetRow[] {
 
     for (const [col, headerName] of colToHeaderName.entries()) {
       sheetRow[headerName] = rowCells.get(col) ?? '';
-    }
-
-    // Support 'var' as key column header for consumers expecting .key
-    if (sheetRow.var !== undefined && sheetRow.key === undefined) {
-      sheetRow.key = sheetRow.var;
     }
 
     // Only include rows that have at least one non-empty value

--- a/src/providers/cryptpad/sheetParser.ts
+++ b/src/providers/cryptpad/sheetParser.ts
@@ -659,3 +659,116 @@ export function buildOnlyOfficeChangePayload(
     isExcel: true,
   });
 }
+
+/**
+ * Encodes a single "add worksheet tab" record into the native OnlyOffice binary format:
+ * AscCH.historyitem_Workbook_SheetAdd (real op code 1, from ONLYOFFICE/sdkjs
+ * `cell/model/History.js` — not a guessed name), UndoRedoDataTypes.SheetAdd (25, from
+ * `cell/model/UndoRedo.js`), with a generic property list matching
+ * `UndoRedoData_SheetAdd.prototype.Properties` (`name`=0, `sheetidfrom`=1, `sheetid`=2,
+ * `tableNames`=3, `insertBefore`=4, `opt_sheet`=5, `opt_sheetidToAdd`=6).
+ *
+ * Field layout was derived and verified against two independent real "add sheet"
+ * records captured from a live OnlyOffice browser session on a CryptPad pad (see
+ * issue #161): the body length implied by summing the fixed structural bytes plus the
+ * two variable-length UTF-16LE strings matched the actual captured body length exactly
+ * in both captures, and the `insertBefore` value matched the sheet's real insert
+ * position in both.
+ *
+ * Each optional/unused property (`sheetidfrom`, `tableNames`, `opt_sheet`,
+ * `opt_sheetidToAdd`) is written as its observed constant "null" marker byte — real
+ * OnlyOffice clients only populate them for operations this encoder doesn't need to
+ * perform (e.g. duplicating an existing sheet).
+ *
+ * @param name - Display name for the new sheet tab.
+ * @param sheetId - Freeform internal sheet identifier (see {@link generateOnlyOfficeSheetId}).
+ * @param insertBeforeIndex - 0-based tab position to insert at (0-255; real captures never
+ *   exceeded a handful of tabs, and the wire format observed here only ever used one byte).
+ */
+export function encodeOnlyOfficeSheetAddRecord(
+  name: string,
+  sheetId: string,
+  insertBeforeIndex: number,
+): Buffer {
+  if (!Number.isInteger(insertBeforeIndex) || insertBeforeIndex < 0 || insertBeforeIndex > 255) {
+    throw new Error(
+      `encodeOnlyOfficeSheetAddRecord: insertBeforeIndex must be an integer 0-255 (got ${insertBeforeIndex}).`,
+    );
+  }
+
+  const nameBuf = Buffer.from(name, 'utf16le');
+  const nameLen = Buffer.alloc(4);
+  nameLen.writeUInt32LE(nameBuf.length, 0);
+
+  const sheetIdBuf = Buffer.from(sheetId, 'utf16le');
+  const sheetIdLen = Buffer.alloc(4);
+  sheetIdLen.writeUInt32LE(sheetIdBuf.length, 0);
+
+  const propertyBlock = Buffer.concat([
+    Buffer.from([0x00, 0x08]), // property 0 "name": type tag 0x08 = string
+    nameLen,
+    nameBuf,
+    Buffer.from([0x01, 0x00]), // property 1 "sheetidfrom": unset (null marker)
+    Buffer.from([0x02, 0x08]), // property 2 "sheetid": type tag 0x08 = string
+    sheetIdLen,
+    sheetIdBuf,
+    Buffer.from([0x03, 0x01]), // property 3 "tableNames": unset (null marker)
+    Buffer.from([0x04, 0x02, insertBeforeIndex]), // property 4 "insertBefore": type tag 0x02 = number
+    Buffer.from([0x05, 0x01]), // property 5 "opt_sheet": unset (null marker)
+    Buffer.from([0x06, 0x01]), // property 6 "opt_sheetidToAdd": unset (null marker)
+  ]);
+
+  const remainingLen = Buffer.alloc(4);
+  remainingLen.writeUInt32LE(propertyBlock.length, 0);
+
+  const magic = Buffer.alloc(4);
+  magic.writeUInt32BE(0x012b0100, 0); // historyitem_Workbook_SheetAdd
+
+  const body = Buffer.concat([
+    magic,
+    Buffer.from([0x00, 0x19]), // flag, UndoRedoDataTypes.SheetAdd (25)
+    remainingLen,
+    propertyBlock,
+  ]);
+
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  return Buffer.concat([header, body]);
+}
+
+/**
+ * Generates a freeform internal sheetId string in the same shape real OnlyOffice
+ * clients use (`<numeric prefix>_<counter>`, e.g. `"7204278956594729_12"`, per live
+ * capture in #161). The exact value doesn't need to match any specific algorithm —
+ * the field is a free-form string elsewhere in the protocol — only a value that's
+ * unique within the pad.
+ */
+export function generateOnlyOfficeSheetId(): string {
+  return `${Date.now()}${Math.floor(Math.random() * 9000 + 1000)}_1`;
+}
+
+/**
+ * Formats a single "add worksheet tab" operation into an OnlyOffice `saveChanges`
+ * message, structured the same way as {@link buildOnlyOfficeChangePayload}
+ * (txOpen marker followed by one record).
+ */
+export function buildOnlyOfficeSheetAddPayload(
+  name: string,
+  sheetId: string,
+  insertBeforeIndex: number,
+): string {
+  const txOpen = Buffer.from('0a0000000129000000ff00000000', 'hex');
+  const now = Date.now();
+  const rec = encodeOnlyOfficeSheetAddRecord(name, sheetId, insertBeforeIndex);
+
+  return JSON.stringify({
+    type: 'saveChanges',
+    changes: [
+      { change: JSON.stringify(`${txOpen.length};${txOpen.toString('base64')}`), time: now },
+      { change: JSON.stringify(`${rec.length};${rec.toString('base64')}`), time: now },
+    ],
+    startSaveChanges: true,
+    endSaveChanges: true,
+    isExcel: true,
+  });
+}

--- a/tests/providers/cryptpad/clientDirect.test.ts
+++ b/tests/providers/cryptpad/clientDirect.test.ts
@@ -22,6 +22,7 @@ describe('CryptPadClient direct methods', () => {
         },
       },
       sheetNames: ['common'],
+      sheetIds: { common: '8200316732097412_745' },
       metadata: { app: 'sheet', mode: 'edit', channelId: 'c1', rtChannelId: 'rt1' },
     });
 
@@ -171,6 +172,67 @@ describe('CryptPadClient direct methods', () => {
     expect(innerJson.content.channel).toBe(channelId);
   });
 
+  it('createSheet broadcasts a real Sheet_Add record to the existing RT channel and returns the new sheetId', async () => {
+    const client = new CryptPadClient({
+      url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890/',
+    });
+
+    vi.spyOn(client, 'fetchSheetData').mockResolvedValue({
+      url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890',
+      cells: {},
+      rows: [],
+      sheets: { common: { cells: {}, rows: [] } },
+      sheetNames: ['common'],
+      sheetIds: { common: 'existing-id' },
+      metadata: { app: 'sheet', mode: 'edit', channelId: 'c1', rtChannelId: 'rt-chan-1' },
+    });
+    vi.spyOn(client, 'getWebsocketUrl').mockResolvedValue('wss://cryptpad.fr/cryptpad_websocket');
+    const broadcastSpy = vi
+      .spyOn(netfluxModule, 'broadcastChannelMessage')
+      .mockResolvedValue(undefined);
+
+    const newSheetId = await client.createSheet('checkout');
+
+    expect(typeof newSheetId).toBe('string');
+    expect(newSheetId).not.toBe('existing-id');
+    expect(broadcastSpy).toHaveBeenCalledTimes(1);
+    const [wsUrl, channel, , payload] = broadcastSpy.mock.calls[0];
+    expect(wsUrl).toBe('wss://cryptpad.fr/cryptpad_websocket');
+    expect(channel).toBe('rt-chan-1'); // broadcasts to the existing RT channel, not the metadata channel
+
+    const parsed = JSON.parse(payload);
+    expect(parsed.type).toBe('saveChanges');
+    expect(parsed.changes).toHaveLength(2); // txOpen + the sheet-add record
+  });
+
+  it('createSheet auto-initializes the RT channel first when the pad has never been opened by a real client', async () => {
+    const client = new CryptPadClient({
+      url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890/',
+    });
+
+    vi.spyOn(client, 'fetchSheetData').mockResolvedValue({
+      url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890',
+      cells: {},
+      rows: [],
+      sheets: {},
+      sheetNames: [],
+      metadata: { app: 'sheet', mode: 'edit', channelId: 'c1' }, // no rtChannelId
+    });
+    vi.spyOn(client, 'getWebsocketUrl').mockResolvedValue('wss://cryptpad.fr/cryptpad_websocket');
+    const initSpy = vi
+      .spyOn(client, 'initializeRtChannel')
+      .mockResolvedValue('abcdef1234567890abcdef1234567890');
+    const broadcastSpy = vi
+      .spyOn(netfluxModule, 'broadcastChannelMessage')
+      .mockResolvedValue(undefined);
+
+    await client.createSheet('common');
+
+    expect(initSpy).toHaveBeenCalledOnce();
+    const [, channel] = broadcastSpy.mock.calls[0];
+    expect(channel).toBe('abcdef1234567890abcdef1234567890');
+  });
+
   it('fetchSheetData retrieves metadata and RT channel changes', async () => {
     const client = new CryptPadClient({
       url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890/',
@@ -239,10 +301,12 @@ describe('CryptPadClient direct methods', () => {
       metadata: { app: 'sheet', mode: 'edit', channelId: 'c1' },
     });
 
+    const createSheetSpy = vi.spyOn(client, 'createSheet').mockResolvedValue('new-sheet-id');
     const sendSpy = vi.spyOn(client, 'sendCellUpdates').mockResolvedValue(undefined);
 
     // Incoming row with 'var'
     await client.writeSheetRows('empty', [{ var: 'intro.title', en: 'Hi' }]);
+    expect(createSheetSpy).toHaveBeenCalledWith('empty', 0, undefined);
     expect(sendSpy).toHaveBeenCalledTimes(1);
 
     // Incoming row with 'key'
@@ -266,6 +330,7 @@ describe('CryptPadClient direct methods', () => {
         },
       },
       sheetNames: ['common'],
+      sheetIds: { common: '8200316732097412_745' },
       metadata: { app: 'sheet', mode: 'edit', channelId: 'c1' },
     });
 
@@ -282,7 +347,7 @@ describe('CryptPadClient direct methods', () => {
     expect(updates.some((u) => u.value === 'Nuevo')).toBe(true);
   });
 
-  it('writeSheetRows throws instead of guessing a sheetId when the target sheet has no matching tab and the pad has multiple tabs', async () => {
+  it('writeSheetRows creates a new tab (via createSheet) when the target sheet has no matching tab, mirroring Google Sheets addSheet-on-missing-sheet', async () => {
     const client = new CryptPadClient({
       url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890/',
     });
@@ -300,13 +365,18 @@ describe('CryptPadClient direct methods', () => {
       metadata: { app: 'sheet', mode: 'edit', channelId: 'c1' },
     });
 
+    const createSheetSpy = vi
+      .spyOn(client, 'createSheet')
+      .mockResolvedValue('8200316732097412_999');
     const sendSpy = vi.spyOn(client, 'sendCellUpdates').mockResolvedValue(undefined);
 
-    await expect(
-      client.writeSheetRows('checkout', [{ var: 'new.key', en: 'New' }]),
-    ).rejects.toThrow(/checkout.*not found among this pad's existing tabs.*common, auth/s);
+    await client.writeSheetRows('checkout', [{ var: 'new.key', en: 'New' }]);
 
-    expect(sendSpy).not.toHaveBeenCalled();
+    // Inserted after the 2 existing tabs, matching Google's "just append" behavior.
+    expect(createSheetSpy).toHaveBeenCalledWith('checkout', 2, undefined);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const updates = sendSpy.mock.calls[0][0];
+    expect(updates.every((u) => u.sheetId === '8200316732097412_999')).toBe(true);
   });
 
   it('fetchSheetData handles sheets that have no cells in groupedCells', async () => {

--- a/tests/providers/cryptpad/clientDirect.test.ts
+++ b/tests/providers/cryptpad/clientDirect.test.ts
@@ -282,6 +282,33 @@ describe('CryptPadClient direct methods', () => {
     expect(updates.some((u) => u.value === 'Nuevo')).toBe(true);
   });
 
+  it('writeSheetRows throws instead of guessing a sheetId when the target sheet has no matching tab and the pad has multiple tabs', async () => {
+    const client = new CryptPadClient({
+      url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890/',
+    });
+
+    vi.spyOn(client, 'fetchSheetData').mockResolvedValue({
+      url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890',
+      cells: {},
+      rows: [],
+      sheets: {
+        common: { cells: {}, rows: [] },
+        auth: { cells: {}, rows: [] },
+      },
+      sheetNames: ['common', 'auth'],
+      sheetIds: { common: '8200316732097412_745', auth: '8200316732097412_746' },
+      metadata: { app: 'sheet', mode: 'edit', channelId: 'c1' },
+    });
+
+    const sendSpy = vi.spyOn(client, 'sendCellUpdates').mockResolvedValue(undefined);
+
+    await expect(
+      client.writeSheetRows('checkout', [{ var: 'new.key', en: 'New' }]),
+    ).rejects.toThrow(/checkout.*not found among this pad's existing tabs.*common, auth/s);
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
   it('fetchSheetData handles sheets that have no cells in groupedCells', async () => {
     const client = new CryptPadClient({
       url: 'https://cryptpad.fr/sheet/#/2/sheet/edit/seed1234567890/',

--- a/tests/providers/cryptpad/sheetOutputProvider.test.ts
+++ b/tests/providers/cryptpad/sheetOutputProvider.test.ts
@@ -37,6 +37,23 @@ describe('cryptpad sheet output provider', () => {
     expect(authRows).toEqual([{ var: 'login.title', en: 'Welcome', de: 'Willkommen' }]);
   });
 
+  it('never converts rows for the reserved i18n metadata sheet (matches Google Sheets output/sync)', () => {
+    const translations = {
+      en: {
+        i18n: { en: 'English', de: 'German' },
+        common: { 'btn.save': 'Save' },
+      },
+      de: {
+        i18n: { en: 'Englisch', de: 'Deutsch' },
+        common: { 'btn.save': 'Speichern' },
+      },
+    };
+
+    const sheetRows = convertTranslationsToSheetRows(translations);
+    expect(Object.keys(sheetRows)).toEqual(['common']);
+    expect(sheetRows.i18n).toBeUndefined();
+  });
+
   it('defaults to the Google Sheets "var" convention for the key column', () => {
     const translations = {
       en: {

--- a/tests/providers/cryptpad/sheetParser.test.ts
+++ b/tests/providers/cryptpad/sheetParser.test.ts
@@ -12,6 +12,9 @@ import {
   convertCellsToMultiSheetRows,
   encodeOnlyOfficeCellRecord,
   buildOnlyOfficeChangePayload,
+  encodeOnlyOfficeSheetAddRecord,
+  generateOnlyOfficeSheetId,
+  buildOnlyOfficeSheetAddPayload,
 } from '../../../src/providers/cryptpad/sheetParser';
 
 describe('CryptPad sheetParser unit tests', () => {
@@ -280,6 +283,67 @@ describe('CryptPad sheetParser unit tests', () => {
       );
       const result = encodeOnlyOfficeCellRecord('A1', 'Key');
       expect(result.equals(ref)).toBe(true);
+    });
+  });
+
+  describe('encodeOnlyOfficeSheetAddRecord / buildOnlyOfficeSheetAddPayload (issue #161)', () => {
+    // Both reference binaries below were captured live from a real OnlyOffice
+    // browser session adding a sheet tab on a CryptPad pad (see issue #161),
+    // not guessed. Byte-for-byte match against two independent captures
+    // (different name/sheetId/insertBefore values) is the strongest evidence
+    // the field layout is correct, the same standard already applied to
+    // encodeOnlyOfficeCellRecord above.
+    it('matches a live-captured "add sheet" reference binary (insertBefore=1)', () => {
+      const ref = Buffer.from(
+        '51000000012b010000194700000000080c000000530068006500650074003200010002082400000037003200300034003200370038003900350036003500390034003700320039005f003300030104020105010601',
+        'hex',
+      );
+      const result = encodeOnlyOfficeSheetAddRecord('Sheet2', '7204278956594729_3', 1);
+      expect(result.equals(ref)).toBe(true);
+    });
+
+    it('matches a second live-captured "add sheet" reference binary (insertBefore=2, longer sheetId)', () => {
+      const ref = Buffer.from(
+        '53000000012b010000194900000000080c000000530068006500650074003200010002082600000037003200300034003200370038003900350036003500390034003700320039005f0031003200030104020205010601',
+        'hex',
+      );
+      const result = encodeOnlyOfficeSheetAddRecord('Sheet2', '7204278956594729_12', 2);
+      expect(result.equals(ref)).toBe(true);
+    });
+
+    it('rejects an out-of-range insertBeforeIndex instead of silently truncating it', () => {
+      expect(() => encodeOnlyOfficeSheetAddRecord('Sheet2', 'id', -1)).toThrow(/insertBeforeIndex/);
+      expect(() => encodeOnlyOfficeSheetAddRecord('Sheet2', 'id', 256)).toThrow(
+        /insertBeforeIndex/,
+      );
+      expect(() => encodeOnlyOfficeSheetAddRecord('Sheet2', 'id', 1.5)).toThrow(
+        /insertBeforeIndex/,
+      );
+    });
+
+    it('generateOnlyOfficeSheetId produces unique, freeform id-shaped strings', () => {
+      const a = generateOnlyOfficeSheetId();
+      const b = generateOnlyOfficeSheetId();
+      expect(a).toMatch(/^\d+_1$/);
+      expect(b).toMatch(/^\d+_1$/);
+      expect(a).not.toBe(b);
+    });
+
+    it('buildOnlyOfficeSheetAddPayload wraps the record in a saveChanges envelope with a txOpen marker first', () => {
+      const payload = JSON.parse(buildOnlyOfficeSheetAddPayload('common', 'sheet-id-1', 0));
+      expect(payload.type).toBe('saveChanges');
+      expect(payload.startSaveChanges).toBe(true);
+      expect(payload.endSaveChanges).toBe(true);
+      expect(payload.isExcel).toBe(true);
+      expect(payload.changes).toHaveLength(2);
+
+      const txOpen = Buffer.from('0a0000000129000000ff00000000', 'hex');
+      const firstChange = JSON.parse(payload.changes[0].change) as string;
+      expect(firstChange).toBe(`${txOpen.length};${txOpen.toString('base64')}`);
+
+      const rec = encodeOnlyOfficeSheetAddRecord('common', 'sheet-id-1', 0);
+      const secondChange = JSON.parse(payload.changes[1].change) as string;
+      expect(secondChange).toBe(`${rec.length};${rec.toString('base64')}`);
     });
 
     it('ignores empty and whitespace-only column headers in convertCellsToSheetRows', () => {

--- a/tests/providers/cryptpad/sheetParser.test.ts
+++ b/tests/providers/cryptpad/sheetParser.test.ts
@@ -150,7 +150,7 @@ describe('CryptPad sheetParser unit tests', () => {
       expect(convertCellsToSheetRows({ invalid: 'val' })).toEqual([]);
     });
 
-    it('converts grid to rows and auto-aliases var to key', () => {
+    it('converts grid to rows, preserving the real header name (no synthetic key alias)', () => {
       const grid = {
         A1: 'var',
         B1: 'en',
@@ -162,12 +162,36 @@ describe('CryptPad sheetParser unit tests', () => {
 
       const rows = convertCellsToSheetRows(grid);
       expect(rows).toHaveLength(1);
+      // Matches google-spreadsheet's row.toObject() shape: only the sheet's
+      // real header names appear, no synthetic 'key' alias for 'var'.
       expect(rows[0]).toEqual({
         var: 'btn.save',
-        key: 'btn.save',
         en: 'Save',
         de: 'Speichern',
       });
+    });
+
+    it('orders header columns by real spreadsheet position, not by edit-history insertion order', () => {
+      // Simulates a header row whose cells were first written to CryptPad's
+      // history out of left-to-right order (e.g. a locale column added in a
+      // later push) — object key insertion order below is deliberately B, C,
+      // then A, to verify the fix does not depend on Object.entries() order.
+      const grid = {
+        B1: 'en',
+        C1: 'de',
+        A1: 'var',
+        A2: 'btn.save',
+        B2: 'Save',
+        C2: 'Speichern',
+      };
+
+      const rows = convertCellsToSheetRows(grid);
+      expect(rows).toHaveLength(1);
+      // Object.keys() must come back in real column order (var, en, de) so that
+      // transformRowsToSheetData's `Object.keys(rows[0])[0]` picks the true key
+      // column, matching how google-spreadsheet's row.toObject() always reflects
+      // the sheet's real column order.
+      expect(Object.keys(rows[0])).toEqual(['var', 'en', 'de']);
     });
 
     it('groups cells by sheet and converts to multi-sheet rows', () => {

--- a/tests/providers/cryptpad/sheetProvider.test.ts
+++ b/tests/providers/cryptpad/sheetProvider.test.ts
@@ -176,10 +176,11 @@ describe('cryptpad sheet coordinate and cell parser', () => {
     };
 
     const rows = convertCellsToSheetRows(cells);
+    // Matches google-spreadsheet's row.toObject() shape: only the sheet's
+    // real header names appear, no synthetic 'key' alias for 'var'.
     expect(rows).toEqual([
       {
         var: 'saeulen.title',
-        key: 'saeulen.title',
         de: 'Die Säulen der Demokratie',
         en: 'The Pillars of Democracy',
       },


### PR DESCRIPTION
## Summary

Investigation triggered by a report that pushing translations to CryptPad appeared to succeed but left the sheet empty when opened in a browser, and a follow-up concern that the CryptPad transform doesn't behave the same as the Google Sheets transform, so switching providers isn't safe.

Filed 5 issues from that investigation (#161–#165). This PR fixes the three that are unambiguous, verifiable bugs, **including a full real implementation of #161** (not just the interim safety fix originally planned — see below). #164 (unifying the two different sync algorithms) and #165 (formula-linked header cells) remain tracked follow-ups that need a design decision rather than a pure bugfix.

## Fixes

- **#161 — CryptPad push can now create new sheet tabs for real.** Originally this PR only made `writeSheetRows` fail loudly instead of silently guessing a nonexistent `sheetId` when a target sheet didn't exist. It's since been upgraded to a full fix: `CryptPadClient.createSheet()` broadcasts a real OnlyOffice `Workbook_SheetAdd` history record, whose binary layout was derived from the actual ONLYOFFICE/sdkjs source and then verified **byte-for-byte against two independent live captures** from a real OnlyOffice browser session (captured on a CryptPad test pad, with the pad owner's help — see the issue thread). `writeSheetRows` now always creates the target sheet by name when no tab matches, mirroring Google Sheets' `addSheet`-on-missing-sheet behavior exactly — this also retires the old `'6'` default-sheetId guess for brand-new pads, which the same capture showed was never a verified constant (real sheetIds are freeform per-workbook strings). Live-verified end to end: pushed a new sheet to the real test pad and confirmed the resulting wire records match the real protocol shape exactly.

- **#162** — `convertTranslationsToSheetRows` (shared by both the CryptPad output and sync providers) now skips the reserved `i18n` metadata sheet, matching the guard `spreadsheetUpdater.ts` and `findLocalChanges.ts` already enforce on the Google Sheets side. Previously, `push`/`sync` against CryptPad could silently overwrite locale display-name metadata with ordinary translation-key rows.

- **#163** — `convertCellsToSheetRows` derived header/column order from the order cells first appeared while replaying CryptPad's edit history, not from real spreadsheet column position, unlike `google-spreadsheet`'s `row.toObject()` which always reflects the sheet's real order. The shared `transformRowsToSheetData` picks the key column via `Object.keys(rows[0])[0]`, so this could silently pick the wrong key column. Also removed a synthetic `key` alias injected for `var`-headered sheets that Google's row shape never has — confirmed dead (no consumer reads `.key` when `.var` is already present) and only added divergence.

## Test plan

- [x] `npx vitest run` — 896 passed, 5 skipped (new regression tests per fix, including two byte-exact reference-binary tests for the real captured `Sheet_Add` records)
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build` (full build incl. dist-cli, dist-action)
- [x] Live end-to-end verification against a real CryptPad pad: pushed a brand-new sheet via `gst-cryptpad push`, confirmed via `gst-cryptpad inspect` and raw wire-record capture that it matches the real OnlyOffice protocol exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)