### PR TITLE
docs: add Astro integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Node.js package for managing translations stored in Google Sheets.
 - ✅ **Smart Locale Filtering**: Only locales with actual translations in content sheets are included in output files
 - ✅ **TypeScript Support**: Full TypeScript definitions included
 - ✅ **Modular Architecture**: Well-tested, maintainable codebase with clear separation of concerns
-- ✅ **Next.js Integration**: Built-in support for Next.js static export workflows
+- ✅ **Next.js & Astro Integration**: Built-in support for Next.js static export workflows and Astro build-time hooks
 - ✅ **Flexible Configuration**: Customizable paths, wait times, and processing options
 - ✅ **GitHub Action**: One-step CI integration via `el-j/google-sheet-translations@v2` — see [GitHub Action](#github-action)
 
@@ -291,6 +291,7 @@ For more detailed examples, check out the [examples directory](examples) where y
 - Bidirectional sync
 - Auto-translation
 - Next.js integration
+- Astro integration
 
 ## GitHub Action
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,10 @@ The auto-translation feature will add Google Translate formulas in the spreadshe
 
 Shows how to use Google Sheet Translations in a Next.js project using the instrumentation feature.
 
+### Astro Integration (`astro-integration.ts`)
+
+Shows how to refresh translation files automatically before `astro dev` / `astro build` via a small local Astro integration hooking into `astro:config:setup`. See the full walkthrough in `website/guide/astro.md`, including a plain npm-script alternative and reading translations at build/runtime.
+
 ## Running Examples
 
 To run any example, install the dependencies first:

--- a/examples/astro-integration.ts
+++ b/examples/astro-integration.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+// A small local Astro integration that refreshes translation files before
+// `astro dev` / `astro build` run. See website/guide/astro.md for the full
+// walkthrough (including npm-script and runtime-read alternatives).
+//
+// Usage in astro.config.mjs:
+//   import { translationsSync } from './examples/astro-integration';
+//   export default defineConfig({ integrations: [translationsSync()] });
+
+export function translationsSync() {
+  return {
+    name: 'translations-sync',
+    hooks: {
+      'astro:config:setup': async ({ logger, command }) => {
+        if (command === 'preview') return;
+
+        const { getSpreadSheetData } = await import('@el-j/google-sheet-translations');
+
+        await getSpreadSheetData(['home', 'common', 'products'], {
+          translationsOutputDir: './src/i18n/translations',
+          localesOutputPath: './src/i18n/locales.ts',
+          dataJsonPath: './src/lib/languageData.json',
+          waitSeconds: 2,
+        });
+
+        logger.info('Translation files written');
+      },
+    },
+  };
+}

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -28,7 +28,7 @@ if (isPreview) {
 
 export default defineConfig({
   title: '@el-j/google-sheet-translations',
-  description: 'Fetch, sync and manage translations from Google Spreadsheets and CryptPad with TypeScript. Supports Drive folder management, multi-spreadsheet merge, image sync, bidirectional sync, auto-translation, and Next.js integration.',
+  description: 'Fetch, sync and manage translations from Google Spreadsheets and CryptPad with TypeScript. Supports Drive folder management, multi-spreadsheet merge, image sync, bidirectional sync, auto-translation, and Next.js/Astro integration.',
 
   // GitHub Pages base path
   base,
@@ -124,6 +124,7 @@ export default defineConfig({
             { text: 'Public Sheets (No Auth)', link: '/guide/public-sheets' },
             { text: 'Live Demo', link: '/guide/live-demo' },
             { text: 'Next.js Integration', link: '/guide/nextjs' },
+            { text: 'Astro Integration', link: '/guide/astro' },
             { text: 'Locale Filtering', link: '/guide/locale-filtering' },
           ],
         },

--- a/website/guide/astro.md
+++ b/website/guide/astro.md
@@ -1,0 +1,201 @@
+# Astro Integration
+
+The package is a **build-time data fetcher** — it doesn't need any framework-specific
+code to work with Astro. It writes plain JSON/TypeScript files to disk (translations,
+`locales.ts`, `languageData.json`); Astro (via Vite) imports those like any other
+static asset. This guide covers two ways to trigger that fetch — a plain npm script,
+or a small native Astro integration for nicer DX — plus how to read the generated
+files at build time and at runtime, including Astro's built-in i18n routing.
+
+## Setup
+
+::: code-group
+
+```bash [npm]
+npm install @el-j/google-sheet-translations
+```
+
+```bash [pnpm]
+pnpm add @el-j/google-sheet-translations
+```
+
+:::
+
+## Option A — npm script (simplest)
+
+Run the fetch as a `predev`/`prebuild` step, same as any other codegen step in an
+Astro project:
+
+```json
+// package.json
+{
+  "scripts": {
+    "predev": "gst-run-provider pull --sheet-titles=home,common,products",
+    "prebuild": "gst-run-provider pull --sheet-titles=home,common,products",
+    "dev": "astro dev",
+    "build": "astro build"
+  }
+}
+```
+
+Or call the programmatic API from a standalone script (`scripts/fetch-translations.mjs`)
+if you need more control (public sheet, CryptPad, auto-translate, etc. — see
+[Getting Started](/guide/getting-started) and [Non-Google Providers](/guide/non-google-providers)):
+
+```typescript
+// scripts/fetch-translations.mjs
+import { getSpreadSheetData } from '@el-j/google-sheet-translations';
+
+await getSpreadSheetData(['home', 'common', 'products'], {
+  translationsOutputDir: './src/i18n/translations',
+  localesOutputPath: './src/i18n/locales.ts',
+  dataJsonPath: './src/lib/languageData.json',
+  waitSeconds: 2,
+});
+
+console.log('[i18n] Translation files written');
+```
+
+```json
+// package.json
+{
+  "scripts": {
+    "predev": "node scripts/fetch-translations.mjs",
+    "prebuild": "node scripts/fetch-translations.mjs"
+  }
+}
+```
+
+This is enough for most projects — no Astro-specific tooling is actually necessary,
+since Astro (via Vite) will happily import the generated `.json`/`.ts` files like
+any other module.
+
+## Option B — a small native Astro integration
+
+If you'd rather the fetch run automatically as part of `astro dev` / `astro build`
+(no separate npm lifecycle script to remember), write a tiny local
+[Astro integration](https://docs.astro.build/en/reference/integrations-reference/)
+that hooks into `astro:config:setup` — it runs once, in Node, before Astro reads
+anything that might depend on the generated files:
+
+```typescript
+// integrations/translations.ts
+import type { AstroIntegration } from 'astro';
+
+export function translationsSync(): AstroIntegration {
+  return {
+    name: 'translations-sync',
+    hooks: {
+      'astro:config:setup': async ({ logger, command }) => {
+        // Skip on `astro preview` — only refresh on `dev`/`build`
+        if (command === 'preview') return;
+
+        const { getSpreadSheetData } = await import('@el-j/google-sheet-translations');
+
+        await getSpreadSheetData(['home', 'common', 'products'], {
+          translationsOutputDir: './src/i18n/translations',
+          localesOutputPath: './src/i18n/locales.ts',
+          dataJsonPath: './src/lib/languageData.json',
+          waitSeconds: 2,
+        });
+
+        logger.info('Translation files written');
+      },
+    },
+  };
+}
+```
+
+```typescript
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import { translationsSync } from './integrations/translations';
+
+export default defineConfig({
+  integrations: [translationsSync()],
+});
+```
+
+> [!TIP]
+> For CryptPad instead of Google Sheets, swap the dynamic import for
+> `createCryptPadSheetInputProvider` / `runProviderPipeline` — see
+> [Non-Google Providers](/guide/non-google-providers) and the
+> [Provider Runtime Architecture](/guide/provider-runtime) guide.
+
+## Astro's built-in i18n routing
+
+Astro has native [i18n routing](https://docs.astro.build/en/guides/internationalization/)
+config. Feed it directly from the generated `locales.ts`:
+
+```typescript
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import { locales } from './src/i18n/locales'; // auto-generated
+
+export default defineConfig({
+  i18n: {
+    defaultLocale: 'en-GB',
+    locales: locales.map((l) => l.toLowerCase()),
+    routing: { prefixDefaultLocale: false },
+  },
+});
+```
+
+## Reading translations
+
+### At build time (`.astro` frontmatter)
+
+Vite (and therefore Astro) imports JSON natively:
+
+```astro
+---
+// src/pages/[locale]/index.astro
+import en from '../../i18n/translations/en.json';
+import de from '../../i18n/translations/de.json';
+
+const translations = { en, de } as const;
+const { locale } = Astro.params;
+const t = translations[locale as keyof typeof translations] ?? translations.en;
+---
+
+<h1>{t['welcome']}</h1>
+```
+
+### Dynamically, across all locales
+
+For a locale count that isn't fixed at authoring time, use Vite's `import.meta.glob`:
+
+```typescript
+// src/i18n/getTranslations.ts
+const modules = import.meta.glob<{ default: Record<string, string> }>(
+  './translations/*.json',
+  { eager: true },
+);
+
+const translations: Record<string, Record<string, string>> = {};
+for (const [path, mod] of Object.entries(modules)) {
+  const locale = path.match(/([^/]+)\.json$/)?.[1];
+  if (locale) translations[locale] = mod.default;
+}
+
+export function getTranslations(locale: string) {
+  return translations[locale] ?? translations['en'];
+}
+```
+
+```astro
+---
+// src/pages/[locale]/index.astro
+import { getTranslations } from '../../i18n/getTranslations';
+const t = getTranslations(Astro.params.locale ?? 'en');
+---
+
+<h1>{t['welcome']}</h1>
+```
+
+### At runtime (SSR endpoints / islands)
+
+The same `getTranslations()` helper works in an Astro API route or a server-rendered
+page when using [SSR mode](https://docs.astro.build/en/guides/on-demand-rendering/)
+— the JSON files are bundled at build time either way, so there's no extra runtime
+fetch or dependency on the original spreadsheet.

--- a/website/guide/introduction.md
+++ b/website/guide/introduction.md
@@ -33,7 +33,7 @@ The package handles the entire roundtrip:
 
 - **Collaborative Editing**: Translators, copywriters, and content editors work directly in familiar spreadsheets without needing Git access.
 - **Privacy & Sovereignty**: Use [CryptPad](/guide/non-google-providers) when strings cannot be stored on US cloud infrastructure or when zero-auth ingestion is desired.
-- **Framework Agnostic**: Works out of the box with Next.js, Nuxt, Remix, Vite, SvelteKit, or any Node.js application that consumes JSON translations.
+- **Framework Agnostic**: Works out of the box with Next.js, Astro, Nuxt, Remix, Vite, SvelteKit, or any Node.js application that consumes JSON translations.
 - **Automation in CI/CD**: Run zero-config sync via GitHub Actions on a schedule or workflow dispatch.
 - **Type Safety**: Strictly typed row parsing, locale filtering, and auto-generated TypeScript declarations prevent runtime key typos.
 


### PR DESCRIPTION
## Summary

- Adds an Astro Integration guide (`website/guide/astro.md`), registered in the VitePress sidebar next to the existing Next.js guide.
- Adds a matching runnable example (`examples/astro-integration.ts`), listed in `examples/README.md`.
- Mentions Astro alongside Next.js in `README.md` and `website/guide/introduction.md`.

## Why docs instead of a shipped Astro package/integration

This package is a build-time data fetcher — it writes plain JSON/TypeScript files to disk and has no runtime framework coupling. The existing Next.js support works the same way: it's pure documentation (`website/guide/nextjs.md`), calling the existing `getSpreadSheetData()` API from `instrumentation.ts` — no Next.js-specific code ships in the package. This PR mirrors that same pattern for Astro rather than introducing a new package export, peer dependency, and build target for a framework that's already covered by the existing programmatic/CLI API.

The guide covers two options:
1. A plain `predev`/`prebuild` npm script (simplest, no new concepts).
2. A small local Astro integration (`astro:config:setup` hook) for teams that want the fetch to run automatically as part of `astro dev`/`astro build`, plus how to feed the generated `locales.ts` into Astro's built-in i18n routing and read translations at build/runtime.

## Test plan

- [x] `npm run docs:build` — VitePress build completes cleanly with the new page registered and linked from the sidebar, no broken-link errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)